### PR TITLE
Add tags to bots

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -34,6 +34,8 @@ gem 'bootstrap-will_paginate'
 
 gem 'acts_as_follower', github: 'tcocca/acts_as_follower', branch: 'master'
 
+gem 'acts-as-taggable-on', '~> 7.0'
+
 # Use Active Storage variant
 # gem 'image_processing', '~> 1.2'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -68,6 +68,8 @@ GEM
       minitest (>= 5.1)
       tzinfo (~> 2.0)
       zeitwerk (~> 2.3)
+    acts-as-taggable-on (7.0.0)
+      activerecord (>= 5.0, < 6.2)
     addressable (2.7.0)
       public_suffix (>= 2.0.2, < 5.0)
     autoprefixer-rails (10.2.4.0)
@@ -238,6 +240,7 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
+  acts-as-taggable-on (~> 7.0)
   acts_as_follower!
   bootsnap (>= 1.4.4)
   bootstrap (~> 4.6.0)

--- a/app/controllers/bots_controller.rb
+++ b/app/controllers/bots_controller.rb
@@ -1,5 +1,6 @@
 class BotsController < ApplicationController
   before_action :find_bot, only: %i[follow unfollow show]
+  before_action :bot_params, only: %i[create]
 
   # identifies current user type and follow a bot
   def follow
@@ -25,9 +26,27 @@ class BotsController < ApplicationController
     redirect_back fallback_location: posts_path
   end
 
+  def new
+    @bot = Bot.new
+  end
+
+  def create
+    @bot = Bot.new(bot_params)
+
+    if @bot.save
+      redirect_to bot_path(@bot)
+    else
+      render 'new'
+    end
+  end
+
   private
 
   def find_bot
     @bot = Bot.find(params[:id])
+  end
+
+  def bot_params
+    params.require(:bot).permit(:name, :username, :bio, :developer_id)
   end
 end

--- a/app/controllers/bots_controller.rb
+++ b/app/controllers/bots_controller.rb
@@ -31,7 +31,7 @@ class BotsController < ApplicationController
   end
 
   def create
-    @bot = Bot.new(bot_params)
+    @bot = Bot.new(bot_params) 
 
     if @bot.save
       redirect_to bot_path(@bot)
@@ -47,6 +47,6 @@ class BotsController < ApplicationController
   end
 
   def bot_params
-    params.require(:bot).permit(:name, :username, :bio, :developer_id)
+    params.require(:bot).permit(:name, :username, :bio, :developer_id, :tag_list)
   end
 end

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -1,5 +1,5 @@
 class PostsController < ApplicationController
-  before_action :authenticate!
+  before_action :authenticate!, only: %[index]
 
   def index
     if current_developer

--- a/app/models/bot.rb
+++ b/app/models/bot.rb
@@ -9,4 +9,26 @@ class Bot < ApplicationRecord
   def timestamp
     created_at.strftime('%d %B %Y %H:%M')
   end
+
+  # Assign an API key on create
+  before_create do |bot|
+    bot.api_key = bot.generate_api_key
+    bot.api_secret = bot.generate_api_secret
+  end
+
+  # Generate a unique API key
+  def generate_api_key
+    loop do
+      token = SecureRandom.hex(16)
+      break token unless Bot.exists?(api_key: token)
+    end
+  end
+
+  # Generate a unique API secret
+  def generate_api_secret
+    loop do
+      token = SecureRandom.hex(16)
+      break token unless Bot.exists?(api_secret: token)
+    end
+  end
 end

--- a/app/models/bot.rb
+++ b/app/models/bot.rb
@@ -5,6 +5,7 @@ class Bot < ApplicationRecord
   belongs_to :developer
 
   acts_as_followable
+  acts_as_taggable_on :tags
 
   def timestamp
     created_at.strftime('%d %B %Y %H:%M')

--- a/app/views/bots/_post.html.erb
+++ b/app/views/bots/_post.html.erb
@@ -11,13 +11,14 @@
           <p class="fs-mini">
             <%= truncate(strip_tags(post.body), length: 600) %>
           </p>
-          <% if post.bot.followed_by?(current_guest ? current_guest : current_developer) %>
-            <%= link_to "Unfollow", unfollow_bot_path(id: post.bot.id) %>
+          <% if current_guest or current_developer %>
+            <% if post.bot.followed_by?(current_guest ? current_guest : current_developer) %>
+              <%= link_to "Unfollow", unfollow_bot_path(id: post.bot.id) %>
 
-          <% else %>
-            <%= link_to "Follow", follow_bot_path(id: post.bot.id)%>
+            <% else %>
+              <%= link_to "Follow", follow_bot_path(id: post.bot.id)%>
+            <% end %>
           <% end %>
-
           <div class="row">
             <!-- pura gambiarra para alinhar -->
             <p class="fs-mini">&nbsp;&nbsp;&nbsp;Likes

--- a/app/views/bots/new.html.erb
+++ b/app/views/bots/new.html.erb
@@ -8,6 +8,8 @@
     <br/>
     Bio:<%= b.text_field :bio %>
     <br/>
+    Tags:<%= b.text_field :tag_list %> 
+    <br/>
      <%= b.hidden_field :developer_id, value: current_developer.id %>
     <%= b.submit %>
   <% end %>

--- a/app/views/bots/new.html.erb
+++ b/app/views/bots/new.html.erb
@@ -1,0 +1,25 @@
+<br/>
+<% if current_developer %>
+  <div class="container">
+    <%= form_for @bot do |b| %>
+    Name:<%= b.text_field :name %>
+    <br/>
+    Username:<%= b.text_field :username %>
+    <br/>
+    Bio:<%= b.text_field :bio %>
+    <br/>
+     <%= b.hidden_field :developer_id, value: current_developer.id %>
+    <%= b.submit %>
+  <% end %>
+
+  <% if @bot.errors.any? %>
+    <ul class="Signup_Errors">
+      <% for message_error in @bot.errors.full_messages %>
+        <li>*
+          <%= message_error %></li>
+      <% end %>
+    </ul>
+  <% end %>
+</div>
+<% else %>
+<% controller.redirect_to :controller => 'posts' %><% end %>

--- a/app/views/bots/show.html.erb
+++ b/app/views/bots/show.html.erb
@@ -35,6 +35,15 @@
       <%= @bot.api_key %>
     </div>
   <% end %>
+
+  <% if current_guest or current_developer %>
+    <% if @bot.followed_by?(current_guest ? current_guest : current_developer) %>
+      <%= link_to "Unfollow", unfollow_bot_path(id: @bot.id) %>
+
+    <% else %>
+      <%= link_to "Follow", follow_bot_path(id: @bot.id)%>
+    <% end %>
+  <% end %>
 </div>
 
 <h1>

--- a/app/views/bots/show.html.erb
+++ b/app/views/bots/show.html.erb
@@ -44,6 +44,11 @@
       <%= link_to "Follow", follow_bot_path(id: @bot.id)%>
     <% end %>
   <% end %>
+
+  <div class="row">
+    <p>Tags: </p>
+    <%= @bot.tag_list %>
+  </div>
 </div>
 
 <h1>

--- a/app/views/bots/show.html.erb
+++ b/app/views/bots/show.html.erb
@@ -24,9 +24,22 @@
     <p>Created at:</p>
     <%= @bot.timestamp %>
   </div>
+
+  <% if current_developer && current_developer.id == @bot.developer_id %>
+    <div class="row">
+      <p>API secret:</p>
+      <%= @bot.api_secret %>
+    </div>
+    <div class="row">
+      <p>API key:</p>
+      <%= @bot.api_key %>
+    </div>
+  <% end %>
 </div>
 
-<h1> Posts </h1>
+<h1>
+  Posts
+</h1>
 
 <div id="posts">
   <%= render @posts %>

--- a/app/views/posts/_post.html.erb
+++ b/app/views/posts/_post.html.erb
@@ -11,11 +11,13 @@
           <p class="fs-mini">
             <%= truncate(strip_tags(post.body), length: 600) %>
           </p>
-          <% if post.bot.followed_by?(current_guest ? current_guest : current_developer) %>
-            <%= link_to "Unfollow", unfollow_bot_path(id: post.bot.id) %>
+          <% if current_guest or current_developer %>
+            <% if post.bot.followed_by?(current_guest ? current_guest : current_developer) %>
+              <%= link_to "Unfollow", unfollow_bot_path(id: post.bot.id) %>
 
-          <% else %>
-            <%= link_to "Follow", follow_bot_path(id: post.bot.id)%>
+            <% else %>
+              <%= link_to "Follow", follow_bot_path(id: post.bot.id)%>
+            <% end %>
           <% end %>
 
           <div class="row">

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -17,7 +17,7 @@ Rails.application.routes.draw do
 
   resources :posts, only: %i[index show]
 
-  resources :bots, only: %i[follow unfollow show] do
+  resources :bots, only: %i[follow unfollow show create new] do
     member do
       get :follow
       get :unfollow

--- a/db/migrate/20210224222836_change_bot_id_to_api_secrete.rb
+++ b/db/migrate/20210224222836_change_bot_id_to_api_secrete.rb
@@ -1,0 +1,5 @@
+class ChangeBotIdToApiSecrete < ActiveRecord::Migration[6.1]
+  def change
+    rename_column :bots, :bot_id, :api_secret
+  end
+end

--- a/db/migrate/20210225232521_acts_as_taggable_on_migration.acts_as_taggable_on_engine.rb
+++ b/db/migrate/20210225232521_acts_as_taggable_on_migration.acts_as_taggable_on_engine.rb
@@ -1,0 +1,37 @@
+# This migration comes from acts_as_taggable_on_engine (originally 1)
+if ActiveRecord.gem_version >= Gem::Version.new('5.0')
+  class ActsAsTaggableOnMigration < ActiveRecord::Migration[4.2]; end
+else
+  class ActsAsTaggableOnMigration < ActiveRecord::Migration; end
+end
+ActsAsTaggableOnMigration.class_eval do
+  def self.up
+    create_table ActsAsTaggableOn.tags_table do |t|
+      t.string :name
+      t.timestamps
+    end
+
+    create_table ActsAsTaggableOn.taggings_table do |t|
+      t.references :tag, foreign_key: { to_table: ActsAsTaggableOn.tags_table }
+
+      # You should make sure that the column created is
+      # long enough to store the required class names.
+      t.references :taggable, polymorphic: true
+      t.references :tagger, polymorphic: true
+
+      # Limit is created to prevent MySQL error on index
+      # length for MyISAM table type: http://bit.ly/vgW2Ql
+      t.string :context, limit: 128
+
+      t.datetime :created_at
+    end
+
+    add_index ActsAsTaggableOn.taggings_table, :tag_id
+    add_index ActsAsTaggableOn.taggings_table, [:taggable_id, :taggable_type, :context], name: 'taggings_taggable_context_idx'
+  end
+
+  def self.down
+    drop_table ActsAsTaggableOn.taggings_table
+    drop_table ActsAsTaggableOn.tags_table
+  end
+end

--- a/db/migrate/20210225232522_add_missing_unique_indices.acts_as_taggable_on_engine.rb
+++ b/db/migrate/20210225232522_add_missing_unique_indices.acts_as_taggable_on_engine.rb
@@ -1,0 +1,26 @@
+# This migration comes from acts_as_taggable_on_engine (originally 2)
+if ActiveRecord.gem_version >= Gem::Version.new('5.0')
+  class AddMissingUniqueIndices < ActiveRecord::Migration[4.2]; end
+else
+  class AddMissingUniqueIndices < ActiveRecord::Migration; end
+end
+AddMissingUniqueIndices.class_eval do
+  def self.up
+    add_index ActsAsTaggableOn.tags_table, :name, unique: true
+
+    remove_index ActsAsTaggableOn.taggings_table, :tag_id if index_exists?(ActsAsTaggableOn.taggings_table, :tag_id)
+    remove_index ActsAsTaggableOn.taggings_table, name: 'taggings_taggable_context_idx'
+    add_index ActsAsTaggableOn.taggings_table,
+              [:tag_id, :taggable_id, :taggable_type, :context, :tagger_id, :tagger_type],
+              unique: true, name: 'taggings_idx'
+  end
+
+  def self.down
+    remove_index ActsAsTaggableOn.tags_table, :name
+
+    remove_index ActsAsTaggableOn.taggings_table, name: 'taggings_idx'
+
+    add_index ActsAsTaggableOn.taggings_table, :tag_id unless index_exists?(ActsAsTaggableOn.taggings_table, :tag_id)
+    add_index ActsAsTaggableOn.taggings_table, [:taggable_id, :taggable_type, :context], name: 'taggings_taggable_context_idx'
+  end
+end

--- a/db/migrate/20210225232523_add_taggings_counter_cache_to_tags.acts_as_taggable_on_engine.rb
+++ b/db/migrate/20210225232523_add_taggings_counter_cache_to_tags.acts_as_taggable_on_engine.rb
@@ -1,0 +1,20 @@
+# This migration comes from acts_as_taggable_on_engine (originally 3)
+if ActiveRecord.gem_version >= Gem::Version.new('5.0')
+  class AddTaggingsCounterCacheToTags < ActiveRecord::Migration[4.2]; end
+else
+  class AddTaggingsCounterCacheToTags < ActiveRecord::Migration; end
+end
+AddTaggingsCounterCacheToTags.class_eval do
+  def self.up
+    add_column ActsAsTaggableOn.tags_table, :taggings_count, :integer, default: 0
+
+    ActsAsTaggableOn::Tag.reset_column_information
+    ActsAsTaggableOn::Tag.find_each do |tag|
+      ActsAsTaggableOn::Tag.reset_counters(tag.id, ActsAsTaggableOn.taggings_table)
+    end
+  end
+
+  def self.down
+    remove_column ActsAsTaggableOn.tags_table, :taggings_count
+  end
+end

--- a/db/migrate/20210225232524_add_missing_taggable_index.acts_as_taggable_on_engine.rb
+++ b/db/migrate/20210225232524_add_missing_taggable_index.acts_as_taggable_on_engine.rb
@@ -1,0 +1,15 @@
+# This migration comes from acts_as_taggable_on_engine (originally 4)
+if ActiveRecord.gem_version >= Gem::Version.new('5.0')
+  class AddMissingTaggableIndex < ActiveRecord::Migration[4.2]; end
+else
+  class AddMissingTaggableIndex < ActiveRecord::Migration; end
+end
+AddMissingTaggableIndex.class_eval do
+  def self.up
+    add_index ActsAsTaggableOn.taggings_table, [:taggable_id, :taggable_type, :context], name: 'taggings_taggable_context_idx'
+  end
+
+  def self.down
+    remove_index ActsAsTaggableOn.taggings_table, name: 'taggings_taggable_context_idx'
+  end
+end

--- a/db/migrate/20210225232525_change_collation_for_tag_names.acts_as_taggable_on_engine.rb
+++ b/db/migrate/20210225232525_change_collation_for_tag_names.acts_as_taggable_on_engine.rb
@@ -1,0 +1,15 @@
+# This migration comes from acts_as_taggable_on_engine (originally 5)
+# This migration is added to circumvent issue #623 and have special characters
+# work properly
+if ActiveRecord.gem_version >= Gem::Version.new('5.0')
+  class ChangeCollationForTagNames < ActiveRecord::Migration[4.2]; end
+else
+  class ChangeCollationForTagNames < ActiveRecord::Migration; end
+end
+ChangeCollationForTagNames.class_eval do
+  def up
+    if ActsAsTaggableOn::Utils.using_mysql?
+      execute("ALTER TABLE #{ActsAsTaggableOn.tags_table} MODIFY name varchar(255) CHARACTER SET utf8 COLLATE utf8_bin;")
+    end
+  end
+end

--- a/db/migrate/20210225232526_add_missing_indexes_on_taggings.acts_as_taggable_on_engine.rb
+++ b/db/migrate/20210225232526_add_missing_indexes_on_taggings.acts_as_taggable_on_engine.rb
@@ -1,0 +1,23 @@
+# This migration comes from acts_as_taggable_on_engine (originally 6)
+if ActiveRecord.gem_version >= Gem::Version.new('5.0')
+  class AddMissingIndexesOnTaggings < ActiveRecord::Migration[4.2]; end
+else
+  class AddMissingIndexesOnTaggings < ActiveRecord::Migration; end
+end
+AddMissingIndexesOnTaggings.class_eval do
+  def change
+    add_index ActsAsTaggableOn.taggings_table, :tag_id unless index_exists? ActsAsTaggableOn.taggings_table, :tag_id
+    add_index ActsAsTaggableOn.taggings_table, :taggable_id unless index_exists? ActsAsTaggableOn.taggings_table, :taggable_id
+    add_index ActsAsTaggableOn.taggings_table, :taggable_type unless index_exists? ActsAsTaggableOn.taggings_table, :taggable_type
+    add_index ActsAsTaggableOn.taggings_table, :tagger_id unless index_exists? ActsAsTaggableOn.taggings_table, :tagger_id
+    add_index ActsAsTaggableOn.taggings_table, :context unless index_exists? ActsAsTaggableOn.taggings_table, :context
+
+    unless index_exists? ActsAsTaggableOn.taggings_table, [:tagger_id, :tagger_type]
+      add_index ActsAsTaggableOn.taggings_table, [:tagger_id, :tagger_type]
+    end
+
+    unless index_exists? ActsAsTaggableOn.taggings_table, [:taggable_id, :taggable_type, :tagger_id, :context], name: 'taggings_idy'
+      add_index ActsAsTaggableOn.taggings_table, [:taggable_id, :taggable_type, :tagger_id, :context], name: 'taggings_idy'
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,13 +10,13 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_02_20_181420) do
+ActiveRecord::Schema.define(version: 2021_02_24_222836) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
   create_table "bots", force: :cascade do |t|
-    t.string "bot_id", limit: 32, null: false
+    t.string "api_secret", limit: 32, null: false
     t.string "username", limit: 32, null: false
     t.string "api_key", limit: 32, null: false
     t.text "bio", default: ""
@@ -25,6 +25,7 @@ ActiveRecord::Schema.define(version: 2021_02_20_181420) do
     t.string "name", limit: 32, null: false
     t.bigint "developer_id", null: false
     t.index ["developer_id"], name: "index_bots_on_developer_id"
+    t.index ["username"], name: "index_bots_on_username", unique: true
   end
 
   create_table "comments", force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_02_24_222836) do
+ActiveRecord::Schema.define(version: 2021_02_25_232526) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -98,9 +98,37 @@ ActiveRecord::Schema.define(version: 2021_02_24_222836) do
     t.index ["bot_id"], name: "index_posts_on_bot_id"
   end
 
+  create_table "taggings", id: :serial, force: :cascade do |t|
+    t.integer "tag_id"
+    t.string "taggable_type"
+    t.integer "taggable_id"
+    t.string "tagger_type"
+    t.integer "tagger_id"
+    t.string "context", limit: 128
+    t.datetime "created_at"
+    t.index ["context"], name: "index_taggings_on_context"
+    t.index ["tag_id", "taggable_id", "taggable_type", "context", "tagger_id", "tagger_type"], name: "taggings_idx", unique: true
+    t.index ["tag_id"], name: "index_taggings_on_tag_id"
+    t.index ["taggable_id", "taggable_type", "context"], name: "taggings_taggable_context_idx"
+    t.index ["taggable_id", "taggable_type", "tagger_id", "context"], name: "taggings_idy"
+    t.index ["taggable_id"], name: "index_taggings_on_taggable_id"
+    t.index ["taggable_type"], name: "index_taggings_on_taggable_type"
+    t.index ["tagger_id", "tagger_type"], name: "index_taggings_on_tagger_id_and_tagger_type"
+    t.index ["tagger_id"], name: "index_taggings_on_tagger_id"
+  end
+
+  create_table "tags", id: :serial, force: :cascade do |t|
+    t.string "name"
+    t.datetime "created_at"
+    t.datetime "updated_at"
+    t.integer "taggings_count", default: 0
+    t.index ["name"], name: "index_tags_on_name", unique: true
+  end
+
   add_foreign_key "bots", "developers"
   add_foreign_key "comments", "bots"
   add_foreign_key "likes", "bots"
   add_foreign_key "likes", "posts"
   add_foreign_key "posts", "bots"
+  add_foreign_key "taggings", "tags"
 end


### PR DESCRIPTION
### Bots act as taggable - Closes #20 

- Add tags to bots when they're created. 
- Tags must be added separated by comma in the input text field.

It's required to migrate your database before running this branch.