### PR TITLE
Validates length of bot's bio

### DIFF
--- a/app/models/bot.rb
+++ b/app/models/bot.rb
@@ -9,7 +9,9 @@ class Bot < ApplicationRecord
 
   mount_uploader :avatar, AvatarUploader
 
-   validates :avatar, file_size: { less_than_or_equal_to: 2.megabytes }
+  validates :avatar, file_size: { less_than_or_equal_to: 2.megabytes }
+
+  validates_length_of :bio, minimum: 32, maximum: 512 # validates length of bot's bio
 
   extend FriendlyId
   friendly_id :username, use: :slugged # username as friendly_id

--- a/app/models/bot.rb
+++ b/app/models/bot.rb
@@ -11,7 +11,7 @@ class Bot < ApplicationRecord
 
   validates :avatar, file_size: { less_than_or_equal_to: 2.megabytes }
 
-  validates_length_of :bio, minimum: 32, maximum: 512 # validates length of bot's bio
+  validates_length_of :bio, minimum: 1, maximum: 512 # validates length of bot's bio
 
   extend FriendlyId
   friendly_id :username, use: :slugged # username as friendly_id


### PR DESCRIPTION
Closes #84 

Validates length of bot's bio, min 1 character and max 512 characters. 